### PR TITLE
Fallback for includes.

### DIFF
--- a/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/AttoParserBasedComposer.java
+++ b/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/AttoParserBasedComposer.java
@@ -17,20 +17,20 @@ public class AttoParserBasedComposer implements ContentComposer, TemplateCompose
     @Override
     public CompletableFuture<Response<String>> composeTemplate(final Response<String> templateResponse) {
         return parse(bodyOf(templateResponse), ContentRange.allOf(bodyOf(templateResponse)))
-            .composeIncludes()
+            .composeIncludes(contentFetcher, this)
             .thenApply(c -> c.toResponse());
     }
 
     @Override
     public CompletableFuture<Composition> composeContent(final Response<String> templateResponse) {
         return parse(bodyOf(templateResponse), ContentRange.empty())
-            .composeIncludes();
+            .composeIncludes(contentFetcher, this);
     }
 
-    private IncludeHandler parse(final String template, final ContentRange defaultContentRange) {
-        final IncludeHandler includeHandler = new IncludeHandler(contentFetcher, this, defaultContentRange, template);
+    private IncludeProcessor parse(final String template, final ContentRange defaultContentRange) {
+        final IncludeMarkupHandler includeHandler = new IncludeMarkupHandler(defaultContentRange);
         Parser.PARSER.parse(template, includeHandler);
-        return includeHandler;
+        return includeHandler.processor(template);
     }
 
     private static String bodyOf(final Response<String> templateResponse) {

--- a/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/AttoParserBasedComposer.java
+++ b/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/AttoParserBasedComposer.java
@@ -33,7 +33,7 @@ public class AttoParserBasedComposer implements ContentComposer, TemplateCompose
         return includeHandler;
     }
 
-    private static String bodyOf(Response<String> templateResponse) {
+    private static String bodyOf(final Response<String> templateResponse) {
         return templateResponse.payload().orElse("");
     }
 }

--- a/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/ContentFetcher.java
+++ b/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/ContentFetcher.java
@@ -5,5 +5,5 @@ import java.util.concurrent.CompletableFuture;
 import com.spotify.apollo.Response;
 
 public interface ContentFetcher {
-    CompletableFuture<Response<String>> fetch(final String path);
+    CompletableFuture<Response<String>> fetch(String path, String fallback);
 }

--- a/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/IncludeHandler.java
+++ b/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/IncludeHandler.java
@@ -3,6 +3,7 @@ package com.rewedigital.examples.msintegration.composer.composing;
 import static com.rewedigital.examples.msintegration.composer.util.StreamUtil.flatten;
 import static java.util.stream.Collectors.toList;
 
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -11,7 +12,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import org.attoparser.AbstractChainedMarkupHandler;
+import org.attoparser.IMarkupHandler;
 import org.attoparser.ParseException;
+import org.attoparser.output.OutputMarkupHandler;
 import org.attoparser.util.TextUtil;
 
 class IncludeHandler extends AbstractChainedMarkupHandler {
@@ -24,6 +27,9 @@ class IncludeHandler extends AbstractChainedMarkupHandler {
     private final String template;
 
     private Optional<IncludedService> include = Optional.empty();
+    private StringWriter fallbackWriter;
+    private IMarkupHandler next;
+    private boolean collectAttributes = false;
 
     public IncludeHandler(final ContentFetcher contentFetcher, final ContentComposer composer,
         final ContentRange defaultContentRange, final String template) {
@@ -31,10 +37,11 @@ class IncludeHandler extends AbstractChainedMarkupHandler {
         this.template = template;
         this.contentFetcher = Objects.requireNonNull(contentFetcher);
         this.composer = Objects.requireNonNull(composer);
+        next = super.getNext();
     }
 
     public CompletableFuture<Composition> composeIncludes() {
-        Stream<CompletableFuture<Composition>> composedIncludes = includedServices.stream()
+        final Stream<CompletableFuture<Composition>> composedIncludes = includedServices.stream()
             .filter(s -> s.isInRage(contentRange()))
             .map(s -> s.fetch(contentFetcher)
                 .thenCompose(r -> r.compose(composer)));
@@ -54,11 +61,29 @@ class IncludeHandler extends AbstractChainedMarkupHandler {
     public void handleOpenElementStart(final char[] buffer, final int nameOffset, final int nameLen, final int line,
         final int col)
         throws ParseException {
-        super.handleOpenElementStart(buffer, nameOffset, nameLen, line, col);
+        next.handleOpenElementStart(buffer, nameOffset, nameLen, line, col);
         if (isIncludeElement(buffer, nameOffset, nameLen)) {
             final IncludedService value = new IncludedService();
             value.startOffset(nameOffset - 1);
             include = Optional.of(value);
+            collectAttributes = true;
+
+            // Store the content..
+            fallbackWriter = new StringWriter();
+            next = new OutputMarkupHandler(fallbackWriter);
+        }
+    }
+
+    @Override
+    public void handleOpenElementEnd(
+        final char[] buffer,
+        final int nameOffset, final int nameLen,
+        final int line, final int col)
+        throws ParseException {
+        if (isIncludeElement(buffer, nameOffset, nameLen)) {
+            collectAttributes = false;
+        } else {
+            next.handleOpenElementEnd(buffer, nameOffset, nameLen, line, col);
         }
     }
 
@@ -68,12 +93,27 @@ class IncludeHandler extends AbstractChainedMarkupHandler {
         final int operatorCol, final int valueContentOffset, final int valueContentLen, final int valueOuterOffset,
         final int valueOuterLen, final int valueLine, final int valueCol)
         throws ParseException {
-        super.handleAttribute(buffer, nameOffset, nameLen, nameLine, nameCol, operatorOffset, operatorLen, operatorLine,
-            operatorCol, valueContentOffset, valueContentLen, valueOuterOffset, valueOuterLen, valueLine, valueCol);
-        if (include.isPresent()) {
+
+        if (collectAttributes) {
             final IncludedService includedService = include.get();
             includedService.put(new String(buffer, nameOffset, nameLen),
                 new String(buffer, valueContentOffset, valueContentLen));
+        } else {
+            next.handleAttribute(buffer, nameOffset, nameLen, nameLine, nameCol, operatorOffset, operatorLen,
+                operatorLine, operatorCol, valueContentOffset, valueContentLen, valueOuterOffset, valueOuterLen,
+                valueLine, valueCol);
+        }
+
+    }
+
+    @Override
+    public void handleCloseElementStart(
+        final char[] buffer,
+        final int nameOffset, final int nameLen,
+        final int line, final int col)
+        throws ParseException {
+        if (!isIncludeElement(buffer, nameOffset, nameLen)) {
+            next.handleCloseElementStart(buffer, nameOffset, nameLen, line, col);
         }
     }
 
@@ -81,16 +121,215 @@ class IncludeHandler extends AbstractChainedMarkupHandler {
     public void handleCloseElementEnd(final char[] buffer, final int nameOffset, final int nameLen, final int line,
         final int col)
         throws ParseException {
-        super.handleCloseElementEnd(buffer, nameOffset, nameLen, line, col);
         if (isIncludeElement(buffer, nameOffset, nameLen) && include.isPresent()) {
             final IncludedService value = include.get();
             value.endOffset(nameOffset + nameLen + 1);
+            value.fallback(fallbackWriter.toString());
             includedServices.add(value);
             include = Optional.empty();
+
+            // reset the chain
+            fallbackWriter = null;
+            next = super.getNext();
         }
+        next.handleCloseElementEnd(buffer, nameOffset, nameLen, line, col);
     }
 
     private boolean isIncludeElement(final char[] buffer, final int nameOffset, final int nameLen) {
         return TextUtil.contains(true, buffer, nameOffset, nameLen, INCLUDE, 0, INCLUDE.length);
+    }
+
+    @Override
+    public void handleDocumentStart(
+        final long startTimeNanos, final int line, final int col)
+        throws ParseException {
+        next.handleDocumentStart(startTimeNanos, line, col);
+    }
+
+    @Override
+    public void handleDocumentEnd(
+        final long endTimeNanos, final long totalTimeNanos, final int line, final int col)
+        throws ParseException {
+        next.handleDocumentEnd(endTimeNanos, totalTimeNanos, line, col);
+    }
+
+    @Override
+    public void handleXmlDeclaration(
+        final char[] buffer,
+        final int keywordOffset, final int keywordLen,
+        final int keywordLine, final int keywordCol,
+        final int versionOffset, final int versionLen,
+        final int versionLine, final int versionCol,
+        final int encodingOffset, final int encodingLen,
+        final int encodingLine, final int encodingCol,
+        final int standaloneOffset, final int standaloneLen,
+        final int standaloneLine, final int standaloneCol,
+        final int outerOffset, final int outerLen,
+        final int line, final int col)
+        throws ParseException {
+        next.handleXmlDeclaration(
+            buffer,
+            keywordOffset, keywordLen, keywordLine, keywordCol,
+            versionOffset, versionLen, versionLine, versionCol,
+            encodingOffset, encodingLen, encodingLine, encodingCol,
+            standaloneOffset, standaloneLen, standaloneLine, standaloneCol,
+            outerOffset, outerLen, line, col);
+    }
+
+    @Override
+    public void handleDocType(
+        final char[] buffer,
+        final int keywordOffset, final int keywordLen,
+        final int keywordLine, final int keywordCol,
+        final int elementNameOffset, final int elementNameLen,
+        final int elementNameLine, final int elementNameCol,
+        final int typeOffset, final int typeLen,
+        final int typeLine, final int typeCol,
+        final int publicIdOffset, final int publicIdLen,
+        final int publicIdLine, final int publicIdCol,
+        final int systemIdOffset, final int systemIdLen,
+        final int systemIdLine, final int systemIdCol,
+        final int internalSubsetOffset, final int internalSubsetLen,
+        final int internalSubsetLine, final int internalSubsetCol,
+        final int outerOffset, final int outerLen,
+        final int outerLine, final int outerCol)
+        throws ParseException {
+        next.handleDocType(
+            buffer,
+            keywordOffset, keywordLen, keywordLine, keywordCol,
+            elementNameOffset, elementNameLen, elementNameLine, elementNameCol,
+            typeOffset, typeLen, typeLine, typeCol,
+            publicIdOffset, publicIdLen, publicIdLine, publicIdCol,
+            systemIdOffset, systemIdLen, systemIdLine, systemIdCol,
+            internalSubsetOffset, internalSubsetLen, internalSubsetLine, internalSubsetCol,
+            outerOffset, outerLen, outerLine, outerCol);
+    }
+
+    @Override
+    public void handleCDATASection(
+        final char[] buffer,
+        final int contentOffset, final int contentLen,
+        final int outerOffset, final int outerLen,
+        final int line, final int col)
+        throws ParseException {
+        next.handleCDATASection(buffer, contentOffset, contentLen, outerOffset, outerLen, line, col);
+    }
+
+    @Override
+    public void handleComment(
+        final char[] buffer,
+        final int contentOffset, final int contentLen,
+        final int outerOffset, final int outerLen,
+        final int line, final int col)
+        throws ParseException {
+        next.handleComment(buffer, contentOffset, contentLen, outerOffset, outerLen, line, col);
+    }
+
+    @Override
+    public void handleText(
+        final char[] buffer,
+        final int offset, final int len,
+        final int line, final int col)
+        throws ParseException {
+        next.handleText(buffer, offset, len, line, col);
+    }
+
+    @Override
+    public void handleStandaloneElementStart(
+        final char[] buffer,
+        final int nameOffset, final int nameLen,
+        final boolean minimized, final int line, final int col)
+        throws ParseException {
+        next.handleStandaloneElementStart(buffer, nameOffset, nameLen, minimized, line, col);
+    }
+
+    @Override
+    public void handleStandaloneElementEnd(
+        final char[] buffer,
+        final int nameOffset, final int nameLen,
+        final boolean minimized, final int line, final int col)
+        throws ParseException {
+        next.handleStandaloneElementEnd(buffer, nameOffset, nameLen, minimized, line, col);
+    }
+
+    @Override
+    public void handleAutoOpenElementStart(
+        final char[] buffer,
+        final int nameOffset, final int nameLen,
+        final int line, final int col)
+        throws ParseException {
+        next.handleAutoOpenElementStart(buffer, nameOffset, nameLen, line, col);
+    }
+
+    @Override
+    public void handleAutoOpenElementEnd(
+        final char[] buffer,
+        final int nameOffset, final int nameLen,
+        final int line, final int col)
+        throws ParseException {
+        next.handleAutoOpenElementEnd(buffer, nameOffset, nameLen, line, col);
+    }
+
+
+    @Override
+    public void handleAutoCloseElementStart(
+        final char[] buffer,
+        final int nameOffset, final int nameLen,
+        final int line, final int col)
+        throws ParseException {
+        next.handleAutoCloseElementStart(buffer, nameOffset, nameLen, line, col);
+    }
+
+    @Override
+    public void handleAutoCloseElementEnd(
+        final char[] buffer,
+        final int nameOffset, final int nameLen,
+        final int line, final int col)
+        throws ParseException {
+        next.handleAutoCloseElementEnd(buffer, nameOffset, nameLen, line, col);
+    }
+
+    @Override
+    public void handleUnmatchedCloseElementStart(
+        final char[] buffer,
+        final int nameOffset, final int nameLen,
+        final int line, final int col)
+        throws ParseException {
+        next.handleUnmatchedCloseElementStart(buffer, nameOffset, nameLen, line, col);
+    }
+
+    @Override
+    public void handleUnmatchedCloseElementEnd(
+        final char[] buffer,
+        final int nameOffset, final int nameLen,
+        final int line, final int col)
+        throws ParseException {
+        next.handleUnmatchedCloseElementEnd(buffer, nameOffset, nameLen, line, col);
+    }
+
+    @Override
+    public void handleInnerWhiteSpace(
+        final char[] buffer,
+        final int offset, final int len,
+        final int line, final int col)
+        throws ParseException {
+        next.handleInnerWhiteSpace(buffer, offset, len, line, col);
+    }
+
+    @Override
+    public void handleProcessingInstruction(
+        final char[] buffer,
+        final int targetOffset, final int targetLen,
+        final int targetLine, final int targetCol,
+        final int contentOffset, final int contentLen,
+        final int contentLine, final int contentCol,
+        final int outerOffset, final int outerLen,
+        final int line, final int col)
+        throws ParseException {
+        next.handleProcessingInstruction(
+            buffer,
+            targetOffset, targetLen, targetLine, targetCol,
+            contentOffset, contentLen, contentLine, contentCol,
+            outerOffset, outerLen, line, col);
     }
 }

--- a/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/IncludeProcessor.java
+++ b/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/IncludeProcessor.java
@@ -1,0 +1,36 @@
+package com.rewedigital.examples.msintegration.composer.composing;
+
+import static com.rewedigital.examples.msintegration.composer.util.StreamUtil.flatten;
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+class IncludeProcessor {
+
+    private final List<IncludedService> includedServices;
+    private final ContentRange contentRange;
+    private final List<String> assetLinks;
+    private final String template;
+
+    public IncludeProcessor(final String template, final List<IncludedService> includedServices,
+        final ContentRange contentRange,
+        final List<String> assetLinks) {
+        this.template = template;
+        this.includedServices = includedServices;
+        this.contentRange = contentRange;
+        this.assetLinks = assetLinks;
+    }
+
+    public CompletableFuture<Composition> composeIncludes(final ContentFetcher contentFetcher,
+        final ContentComposer composer) {
+        final Stream<CompletableFuture<Composition>> composedIncludes = includedServices.stream()
+            .filter(s -> s.isInRage(contentRange))
+            .map(s -> s.fetch(contentFetcher)
+                .thenCompose(r -> r.compose(composer)));
+        return flatten(composedIncludes)
+            .thenApply(c -> new Composition(template, contentRange, assetLinks, c.collect(toList())));
+    }
+
+}

--- a/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/IncludeProcessor.java
+++ b/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/IncludeProcessor.java
@@ -15,8 +15,7 @@ class IncludeProcessor {
     private final String template;
 
     public IncludeProcessor(final String template, final List<IncludedService> includedServices,
-        final ContentRange contentRange,
-        final List<String> assetLinks) {
+        final ContentRange contentRange, final List<String> assetLinks) {
         this.template = template;
         this.includedServices = includedServices;
         this.contentRange = contentRange;

--- a/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/IncludedService.java
+++ b/composer/src/main/java/com/rewedigital/examples/msintegration/composer/composing/IncludedService.java
@@ -13,7 +13,7 @@ class IncludedService {
         private final int endOffset;
         private final Response<String> response;
 
-        private WithResponse(int startOffset, int endOffset, Response<String> response) {
+        private WithResponse(final int startOffset, final int endOffset, final Response<String> response) {
             this.startOffset = startOffset;
             this.endOffset = endOffset;
             this.response = response;
@@ -28,29 +28,38 @@ class IncludedService {
 
     private int startOffset;
     private int endOffset;
-    private Map<String, String> attributes = new HashMap<>();
+    private final Map<String, String> attributes = new HashMap<>();
+    private String fallback;
 
-    public void startOffset(int startOffset) {
+    public void startOffset(final int startOffset) {
         this.startOffset = startOffset;
     }
 
-    public void put(String name, String value) {
-        attributes.put(name, value);
-    }
-
-    public void endOffset(int endOffset) {
+    public void endOffset(final int endOffset) {
         this.endOffset = endOffset;
     }
 
+    public void put(final String name, final String value) {
+        attributes.put(name, value);
+    }
+
+    public void fallback(final String fallback) {
+        this.fallback = fallback;
+    }
+
     public CompletableFuture<IncludedService.WithResponse> fetch(final ContentFetcher fetcher) {
-        return fetcher.fetch(path()).thenApply(r -> new WithResponse(startOffset, endOffset, r));
+        return fetcher.fetch(path(), fallback()).thenApply(r -> new WithResponse(startOffset, endOffset, r));
+    }
+
+    private String fallback() {
+        return fallback;
     }
 
     private String path() {
         return attributes.getOrDefault("path", "");
     }
 
-    public boolean isInRage(ContentRange contentRange) {
+    public boolean isInRage(final ContentRange contentRange) {
         return contentRange.isInRange(startOffset);
     }
 

--- a/composer/src/main/java/com/rewedigital/examples/msintegration/composer/proxy/ValidatingContentFetcher.java
+++ b/composer/src/main/java/com/rewedigital/examples/msintegration/composer/proxy/ValidatingContentFetcher.java
@@ -29,7 +29,7 @@ public class ValidatingContentFetcher implements ContentFetcher {
     }
 
     @Override
-    public CompletableFuture<Response<String>> fetch(final String path) {
+    public CompletableFuture<Response<String>> fetch(final String path, final String fallback) {
         if (path == null || path.trim().isEmpty()) {
             LOGGER.warn("Empty path attribute in include found");
             return CompletableFuture.completedFuture(Response.forPayload(""));
@@ -38,12 +38,13 @@ public class ValidatingContentFetcher implements ContentFetcher {
         final String expandedPath = UriTemplate.fromTemplate(path).expand(parsedPathArguments);
         return client.send(Request.forUri(expandedPath, "GET"))
             .thenApply(this::acceptHtmlOnly)
-            .thenApply(this::toStringPayload)
+            .thenApply(r -> toStringPayload(r, fallback))
             .toCompletableFuture();
     }
 
-    private Response<String> toStringPayload(final Response<ByteString> response) {
-        return response.withPayload(response.payload().map(p -> p.utf8()).orElse(""));
+    private Response<String> toStringPayload(final Response<ByteString> response, final String fallback) {
+        final String value = response.payload().map(p -> p.utf8()).orElse(fallback);
+        return response.withPayload(value);
     }
 
     private Response<ByteString> acceptHtmlOnly(final Response<ByteString> response) {
@@ -51,6 +52,6 @@ public class ValidatingContentFetcher implements ContentFetcher {
         if (contentType != null && contentType.contains("text/html")) {
             return response;
         }
-        return response.withPayload(ByteString.EMPTY);
+        return response.withPayload(null);
     }
 }

--- a/composer/src/test/java/com/rewedigital/examples/msintegration/composer/composing/ContentMarkupHandlerTest.java
+++ b/composer/src/test/java/com/rewedigital/examples/msintegration/composer/composing/ContentMarkupHandlerTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.rewedigital.examples.msintegration.composer.composing.ContentMarkupHandler;
 import com.rewedigital.examples.msintegration.composer.composing.ContentRange;
 
 public class ContentMarkupHandlerTest {

--- a/composer/src/test/java/com/rewedigital/examples/msintegration/composer/composing/TemplateComposerTest.java
+++ b/composer/src/test/java/com/rewedigital/examples/msintegration/composer/composing/TemplateComposerTest.java
@@ -1,13 +1,16 @@
 package com.rewedigital.examples.msintegration.composer.composing;
 
+import static java.util.Arrays.asList;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static okio.ByteString.encodeUtf8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
@@ -15,6 +18,7 @@ import org.junit.Test;
 import com.rewedigital.examples.msintegration.composer.proxy.ValidatingContentFetcher;
 import com.spotify.apollo.Client;
 import com.spotify.apollo.Response;
+import com.spotify.apollo.Status;
 
 import okio.ByteString;
 
@@ -27,7 +31,7 @@ public class TemplateComposerTest {
         final Response<String> result = composer
             .composeTemplate(r("template <rewe-digital-include></rewe-digital-include> content")).get();
 
-        assertThat(result.payload().get()).isEqualTo("template  content");
+        assertThat(result.payload()).contains("template  content");
     }
 
     @Test
@@ -40,7 +44,7 @@ public class TemplateComposerTest {
                 "template content <rewe-digital-include path=\"http://mock/\"></rewe-digital-include> more content"))
             .get();
 
-        assertThat(result.payload().get()).isEqualTo("template content " + content + " more content");
+        assertThat(result.payload()).contains("template content " + content + " more content");
     }
 
     @Test
@@ -50,7 +54,7 @@ public class TemplateComposerTest {
         final Response<String> result = composer
             .composeTemplate(r("<head></head><rewe-digital-include path=\"http://mock/\"></rewe-digital-include>"))
             .get();
-        assertThat(result.payload().get()).isEqualTo(
+        assertThat(result.payload()).contains(
             "<head><link rel=\"stylesheet\" data-rd-options=\"include\" href=\"css/link\" />\n" +
                 "</head>");
     }
@@ -65,7 +69,17 @@ public class TemplateComposerTest {
         final Response<String> result = composer
             .composeTemplate(r("<rewe-digital-include path=\"http://mock/\"></rewe-digital-include>"))
             .get();
-        assertThat(result.payload().get()).isEqualTo(innerContent);
+        assertThat(result.payload()).contains(innerContent);
+    }
+
+    @Test
+    public void usesFallbackIfContentReturnsWithError() throws Exception {
+        final TemplateComposer composer = makeComposer(aClientReturning(Status.BAD_REQUEST));
+        final Response<String> result = composer
+            .composeTemplate(
+                r("template content <rewe-digital-include path=\"http://mock/\">default content</rewe-digital-include>"))
+            .get();
+        assertThat(result.payload()).contains("template content default content");
     }
 
 
@@ -82,29 +96,40 @@ public class TemplateComposerTest {
 
         final Client client = mock(Client.class);
         when(client.send(any()))
-            .thenReturn(CompletableFuture.completedFuture(response));
+            .thenReturn(completedFuture(response));
         return client;
     }
 
     private Client aClientWithConsecutiveContent(final String firstContent, final String... other) {
         final Client client = mock(Client.class);
         @SuppressWarnings("unchecked")
-        final CompletableFuture<Response<ByteString>>[] otherResponses = Arrays.asList(other)
+        final CompletableFuture<Response<ByteString>>[] otherResponses = asList(other)
             .stream()
-            .map(c -> CompletableFuture.completedFuture(contentResponse(c, "")))
+            .map(c -> completedFuture(contentResponse(c, "")))
             .collect(Collectors.toList()).toArray(new CompletableFuture[0]);
 
-        when(client.send(any())).thenReturn(CompletableFuture.completedFuture(contentResponse(firstContent, "")),
+        when(client.send(any())).thenReturn(completedFuture(contentResponse(firstContent, "")),
             otherResponses);
         return client;
     }
 
+    private Client aClientReturning(final Status status) {
+        final Client client = mock(Client.class);
+        when(client.send(any())).thenReturn(statusResponse(status));
+        return client;
+    }
+
+
     private Response<ByteString> contentResponse(final String content, final String head) {
         return Response
             .forPayload(
-                ByteString.encodeUtf8("<html><head>" + head + "</head><body><rewe-digital-content>" + content
+                encodeUtf8("<html><head>" + head + "</head><body><rewe-digital-content>" + content
                     + "</rewe-digital-content></body></html>"))
             .withHeader("Content-Type", "text/html");
+    }
+
+    private CompletionStage<Response<ByteString>> statusResponse(Status status) {
+        return completedFuture(Response.forStatus(status));
     }
 
     private Response<String> r(String body) {

--- a/composer/src/test/java/com/rewedigital/examples/msintegration/composer/composing/TemplateComposerTest.java
+++ b/composer/src/test/java/com/rewedigital/examples/msintegration/composer/composing/TemplateComposerTest.java
@@ -77,9 +77,9 @@ public class TemplateComposerTest {
         final TemplateComposer composer = makeComposer(aClientReturning(Status.BAD_REQUEST));
         final Response<String> result = composer
             .composeTemplate(
-                r("template content <rewe-digital-include path=\"http://mock/\">default content</rewe-digital-include>"))
+                r("template content <rewe-digital-include path=\"http://mock/\"><rewe-digital-content><div>default content</div></rewe-digital-content></rewe-digital-include>"))
             .get();
-        assertThat(result.payload()).contains("template content default content");
+        assertThat(result.payload().get()).contains("template content <div>default content</div>");
     }
 
 
@@ -92,7 +92,7 @@ public class TemplateComposerTest {
     }
 
     private Client aClientWithSimpleContent(final String content, final String head) {
-        Response<ByteString> response = contentResponse(content, head);
+        final Response<ByteString> response = contentResponse(content, head);
 
         final Client client = mock(Client.class);
         when(client.send(any()))
@@ -128,11 +128,11 @@ public class TemplateComposerTest {
             .withHeader("Content-Type", "text/html");
     }
 
-    private CompletionStage<Response<ByteString>> statusResponse(Status status) {
+    private CompletionStage<Response<ByteString>> statusResponse(final Status status) {
         return completedFuture(Response.forStatus(status));
     }
 
-    private Response<String> r(String body) {
+    private Response<String> r(final String body) {
         return Response.forPayload(body);
     }
 }

--- a/composer/src/test/java/com/rewedigital/examples/msintegration/composer/composing/TemplateComposerTest.java
+++ b/composer/src/test/java/com/rewedigital/examples/msintegration/composer/composing/TemplateComposerTest.java
@@ -103,7 +103,8 @@ public class TemplateComposerTest {
         return Response
             .forPayload(
                 ByteString.encodeUtf8("<html><head>" + head + "</head><body><rewe-digital-content>" + content
-                    + "</rewe-digital-content></body></html>"));
+                    + "</rewe-digital-content></body></html>"))
+            .withHeader("Content-Type", "text/html");
     }
 
     private Response<String> r(String body) {

--- a/composer/src/test/java/com/rewedigital/examples/msintegration/composer/proxy/ValidatingContentFetcherTest.java
+++ b/composer/src/test/java/com/rewedigital/examples/msintegration/composer/proxy/ValidatingContentFetcherTest.java
@@ -1,0 +1,87 @@
+package com.rewedigital.examples.msintegration.composer.proxy;
+
+import static java.util.Collections.emptyMap;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static okio.ByteString.encodeUtf8;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mockito;
+
+import com.spotify.apollo.Client;
+import com.spotify.apollo.Request;
+import com.spotify.apollo.Response;
+
+import okio.ByteString;
+
+public class ValidatingContentFetcherTest {
+
+    @Test
+    public void fetchesEmptyContentForMissingPath() throws Exception {
+        final Response<String> result =
+            new ValidatingContentFetcher(mock(Client.class), emptyMap()).fetch(null).get();
+        assertThat(result.payload()).contains("");
+    }
+
+    @Test
+    public void fetchesContentFromPath() throws Exception {
+        final Client client = mock(Client.class);
+        when(client.send(aRequestWithPath("/some/path"))).thenReturn(aResponse("ok"));
+        Response<String> result =
+            new ValidatingContentFetcher(client, emptyMap()).fetch("/some/path").get();
+        assertThat(result.payload()).contains("ok");
+    }
+
+    @Test
+    public void expandsPathWithParameters() throws Exception {
+        final Client client = mock(Client.class);
+        when(client.send(aRequestWithPath("/some/path/val"))).thenReturn(aResponse("ok"));
+        Response<String> result =
+            new ValidatingContentFetcher(client, params("var", "val")).fetch("/some/path/{var}").get();
+        assertThat(result.payload()).contains("ok");
+    }
+
+    @Test
+    public void defaultsNonHTMLResponsesToEmpty() throws Exception {
+        final Client client = mock(Client.class);
+        when(client.send(aRequestWithPath("/some/path"))).thenReturn(aResponse("ok", "text/json"));
+        Response<String> result =
+            new ValidatingContentFetcher(client, emptyMap()).fetch("/some/path").get();
+        assertThat(result.payload()).contains("");
+    }
+
+    private static Request aRequestWithPath(final String path) {
+        return Mockito.argThat(new ArgumentMatcher<Request>() {
+
+            @Override
+            public boolean matches(final Object argument) {
+                return (Request.class.isAssignableFrom(argument.getClass())) &&
+                    path.equals(((Request) argument).uri());
+            }
+        });
+    }
+
+    private static CompletionStage<Response<ByteString>> aResponse(final String payload) {
+        return aResponse(payload, "text/html");
+    }
+
+    private static CompletionStage<Response<ByteString>> aResponse(final String payload, final String contentType) {
+        return completedFuture(
+            Response.forPayload(encodeUtf8(payload)).withHeader("Content-Type", contentType));
+    }
+
+
+
+    private static Map<String, Object> params(final String name, final String value) {
+        final Map<String, Object> params = new HashMap<>();
+        params.put(name, value);
+        return params;
+    }
+}

--- a/composer/src/test/java/com/rewedigital/examples/msintegration/composer/proxy/ValidatingContentFetcherTest.java
+++ b/composer/src/test/java/com/rewedigital/examples/msintegration/composer/proxy/ValidatingContentFetcherTest.java
@@ -26,7 +26,7 @@ public class ValidatingContentFetcherTest {
     @Test
     public void fetchesEmptyContentForMissingPath() throws Exception {
         final Response<String> result =
-            new ValidatingContentFetcher(mock(Client.class), emptyMap()).fetch(null).get();
+            new ValidatingContentFetcher(mock(Client.class), emptyMap()).fetch(null, null).get();
         assertThat(result.payload()).contains("");
     }
 
@@ -34,8 +34,8 @@ public class ValidatingContentFetcherTest {
     public void fetchesContentFromPath() throws Exception {
         final Client client = mock(Client.class);
         when(client.send(aRequestWithPath("/some/path"))).thenReturn(aResponse("ok"));
-        Response<String> result =
-            new ValidatingContentFetcher(client, emptyMap()).fetch("/some/path").get();
+        final Response<String> result =
+            new ValidatingContentFetcher(client, emptyMap()).fetch("/some/path", "fallback").get();
         assertThat(result.payload()).contains("ok");
     }
 
@@ -43,8 +43,8 @@ public class ValidatingContentFetcherTest {
     public void expandsPathWithParameters() throws Exception {
         final Client client = mock(Client.class);
         when(client.send(aRequestWithPath("/some/path/val"))).thenReturn(aResponse("ok"));
-        Response<String> result =
-            new ValidatingContentFetcher(client, params("var", "val")).fetch("/some/path/{var}").get();
+        final Response<String> result =
+            new ValidatingContentFetcher(client, params("var", "val")).fetch("/some/path/{var}", "fallback").get();
         assertThat(result.payload()).contains("ok");
     }
 
@@ -52,8 +52,8 @@ public class ValidatingContentFetcherTest {
     public void defaultsNonHTMLResponsesToEmpty() throws Exception {
         final Client client = mock(Client.class);
         when(client.send(aRequestWithPath("/some/path"))).thenReturn(aResponse("ok", "text/json"));
-        Response<String> result =
-            new ValidatingContentFetcher(client, emptyMap()).fetch("/some/path").get();
+        final Response<String> result =
+            new ValidatingContentFetcher(client, emptyMap()).fetch("/some/path", "").get();
         assertThat(result.payload()).contains("");
     }
 


### PR DESCRIPTION
Used the usual pattern changing the handler and piping only the inner content to the collector. Decorated the inner content with <rewe-digital-content> as this seems the best work around.